### PR TITLE
Allow `component_manager`s to hold external pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /.vs
 /CMakeUserPresets.json
-

--- a/examples/pong/src/pong.cxx
+++ b/examples/pong/src/pong.cxx
@@ -78,17 +78,16 @@ namespace
         } collision_type;
     };
 
-    class player_movement : public mope::game_system<player_component, mope::transform_component, pong>
+    class player_movement : public mope::game_system<player_component, mope::transform_component, mope::input_state>
     {
         void process_tick(double time_step, component_view components) override
         {
-            for (auto&& [player, transform, scene] : components) {
+            for (auto&& [player, transform, inputs] : components) {
                 auto previous_y = transform.position().y();
                 auto min_showing = 0.5f * (transform.size().y() + transform.size().x());
-                auto y_delta = scene.cursor_deltas.y();
-                auto screen_height = scene.client_size.y();
+                auto y_delta = inputs.cursor_deltas.y();
                 auto new_y = std::max(
-                    std::min(y_delta + previous_y, screen_height - min_showing),
+                    std::min(y_delta + previous_y, OrthoHeight - min_showing),
                     min_showing - transform.size().y()
                 );
                 transform.set_y(new_y);
@@ -278,12 +277,12 @@ namespace
         }
     };
 
-    class exit_on_escape : public mope::game_system<pong>
+    class exit_on_escape : public mope::game_system<mope::input_state, pong>
     {
         void process_tick(double time_step, component_view components)
         {
-            for (auto&& scene : components) {
-                if (scene.pressed_keys.test(mope::glfw::ESCAPE)) {
+            for (auto&& [inputs, scene] : components) {
+                if (inputs.pressed_keys.test(mope::glfw::ESCAPE)) {
                     scene.set_done();
                 }
             }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
     FILES
         "glad/glad.h"
         "KHR/khrplatform.h"
+        "mope_game_engine/components/input_state.hxx"
         "mope_game_engine/components/sprite.hxx"
         "mope_game_engine/components/transform.hxx"
         "mope_game_engine/collisions.hxx"

--- a/include/mope_game_engine/components/input_state.hxx
+++ b/include/mope_game_engine/components/input_state.hxx
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "mope_game_engine/component.hxx"
+#include "mope_vec/mope_vec.hxx"
+
+#include <bitset>
+
+namespace mope
+{
+    /// A singleton component representing the state of the client area and user
+    /// input.
+    struct input_state : public singleton_component
+    {
+        std::bitset<256> pressed_keys;  ///< Keys that were pressed this tick
+        std::bitset<256> released_keys; ///< Keys that were released this tick
+        std::bitset<256> held_keys;     ///< Keys that were still held by the end of this tick
+        vec2f cursor_position;          ///< Position of the cursor relative to the upper left corner of the game window
+        vec2f cursor_deltas;            ///< Motion of the cursor this tick
+        vec2i client_size;              ///< Size in pixels of the game window
+    };
+}

--- a/include/mope_game_engine/game_engine.hxx
+++ b/include/mope_game_engine/game_engine.hxx
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "mope_game_engine/components/input_state.hxx"
 #include "mope_game_engine/mope_game_engine_export.hxx"
 #include "mope_game_engine/texture.hxx"
 
@@ -80,6 +81,7 @@ namespace mope
         std::shared_ptr<I_logger> m_logger;
 
         std::vector<std::unique_ptr<game_scene>> m_scenes;
+        input_state m_input_state;
         double m_ticktime;
 
         gl::texture m_default_texture;

--- a/include/mope_game_engine/game_scene.hxx
+++ b/include/mope_game_engine/game_scene.hxx
@@ -29,13 +29,6 @@ namespace mope
 
         void set_projection_matrix(mat4f const& projection);
 
-        std::bitset<256> pressed_keys;  ///< Keys that were pressed this tick
-        std::bitset<256> released_keys; ///< Keys that were released this tick
-        std::bitset<256> held_keys;     ///< Keys that were still held by the end of this tick
-        vec2f cursor_position;          ///< Position of the cursor relative to the upper left corner of the game window
-        vec2f cursor_deltas;            ///< Motion of the cursor this tick
-        vec2i client_size;              ///< Size in pixels of the game window
-
     private:
         friend class game_engine;
         void tick(game_engine& engine, double time_step);

--- a/src/ecs_manager.cxx
+++ b/src/ecs_manager.cxx
@@ -1,3 +1,4 @@
+#include "mope_game_engine/component.hxx"
 #include "mope_game_engine/ecs_manager.hxx"
 #include "mope_game_engine/game_system.hxx"
 
@@ -8,7 +9,9 @@ mope::ecs_manager::ecs_manager()
     : m_next_entity { 0 }
     , m_component_managers{ }
     , m_game_systems{ }
-{ }
+{
+    set_external_component(this);
+}
 
 mope::ecs_manager::~ecs_manager() = default;
 mope::ecs_manager::ecs_manager(ecs_manager&&) = default;

--- a/src/game_scene.cxx
+++ b/src/game_scene.cxx
@@ -10,17 +10,12 @@
 #include <memory>
 
 mope::game_scene::game_scene()
-    : ecs_manager{}
-    , pressed_keys{ }
-    , released_keys{ }
-    , held_keys{ }
-    , cursor_position{ }
-    , cursor_deltas{ }
-    , client_size{ }
+    : ecs_manager{ }
     , m_sprite_renderer{ }
     , m_initialized{ false }
     , m_done{ false }
-{ }
+{
+}
 
 mope::game_scene::~game_scene() = default;
 


### PR DESCRIPTION
`component_manager`s for `singleton_component`s can hold pointers to external components, rather than managing the lifetime of the component themselves. This allows, for instance, the `ecs_manager` to "set it and forget it" by adding itself as its own component, rather than having to implement special logic in `get_component`. We can also share one instance of a singleton `input_state` component among all of the current scenes.