### PR TITLE
Add the logger to the scenes as a `singleton_component`

### DIFF
--- a/include/mope_game_engine/component.hxx
+++ b/include/mope_game_engine/component.hxx
@@ -129,18 +129,7 @@ namespace mope::detail
     public:
         component_manager()
             : m_data{ }
-        {
-        }
-
-        component_manager(Component data)
-            : m_data{ std::move(data) }
-        {
-        }
-
-        component_manager(Component* external_data)
-            : m_data{ external_data }
-        {
-        }
+        { }
 
         template <typename T>
             requires std::same_as<std::remove_cvref_t<T>, Component>
@@ -190,7 +179,12 @@ namespace mope::detail
         }
 
     private:
-        std::variant<std::monostate, Component, Component*> m_data;
+        using Variant = std::conditional_t<
+            std::is_abstract_v<Component>,
+            std::variant<std::monostate, Component*>,
+            std::variant<std::monostate, Component, Component*>>;
+
+        Variant m_data;
     };
 
     template <derived_from_entity_component Component>

--- a/include/mope_game_engine/game_engine.hxx
+++ b/include/mope_game_engine/game_engine.hxx
@@ -18,7 +18,7 @@ namespace mope
 
 namespace mope
 {
-    class MOPE_GAME_ENGINE_EXPORT I_logger
+    class MOPE_GAME_ENGINE_EXPORT I_logger : public singleton_component
     {
     public:
         virtual ~I_logger() = default;

--- a/src/game_engine.cxx
+++ b/src/game_engine.cxx
@@ -110,6 +110,7 @@ void mope::game_engine::run(I_game_window& window)
 
     for (auto& scene : m_scenes) {
         scene->set_external_component(&m_input_state);
+        scene->set_external_component(m_logger.get());
     }
 
     using seconds = std::chrono::duration<double, std::ratio<1, 1>>;


### PR DESCRIPTION
It is now possible to use the `I_logger` provided to the `game_engine` at startup from any `game_scene` or `game_system`.