### PR TITLE
Fix up loop ending logic

### DIFF
--- a/examples/pong/src/glfw.cxx
+++ b/examples/pong/src/glfw.cxx
@@ -227,10 +227,10 @@ auto mope::glfw::window::wants_to_close() const -> bool
     return ::glfwWindowShouldClose(glfw_window);
 }
 
-void mope::glfw::window::close()
+void mope::glfw::window::close(bool should_close)
 {
     auto glfw_window = static_cast<GLFWwindow*>(m_impl);
-    ::glfwSetWindowShouldClose(glfw_window, GLFW_TRUE);
+    ::glfwSetWindowShouldClose(glfw_window, should_close ? GLFW_TRUE : GLFW_FALSE);
 }
 
 auto mope::glfw::window::key_states() const -> std::bitset<256>

--- a/examples/pong/src/glfw.hxx
+++ b/examples/pong/src/glfw.hxx
@@ -84,7 +84,7 @@ namespace mope::glfw
         void process_inputs() override;
         void swap() override;
         auto wants_to_close() const -> bool override;
-        void close() override;
+        void close(bool should_close) override;
 
         auto key_states() const -> std::bitset<256> override;
         auto cursor_pos() const -> vec2f override;

--- a/include/mope_game_engine/game_engine.hxx
+++ b/include/mope_game_engine/game_engine.hxx
@@ -78,6 +78,10 @@ namespace mope
     private:
         void prepare_gl_resources();
         void release_gl_resources();
+        void load_scenes();
+        void unload_scenes();
+        bool keep_alive(I_game_window& window);
+        void draw(I_game_window& window, double alpha);
 
         std::vector<std::unique_ptr<game_scene>> m_new_scenes;
         std::vector<std::unique_ptr<game_scene>> m_scenes;

--- a/include/mope_game_engine/game_scene.hxx
+++ b/include/mope_game_engine/game_scene.hxx
@@ -42,14 +42,22 @@ namespace mope
         /// Use this to add initial components / systems to the scene. By the
         /// time we get here, the graphics context is ready to use, and all
         /// engine-provided singleton components are available.
-        virtual void on_load(game_engine& engine);
+        virtual void on_load(game_engine& engine) { }
 
         /// Called after your scene returns `true` from `is_done()`, just before
         /// it is deleted.
         ///
         /// TODO: This doesn't really do anything at the moment, but is a likely
         /// place to allow scenes to perform serialization in the future.
-        virtual void on_unload(game_engine& engine);
+        virtual void on_unload(game_engine& engine) { }
+
+        /// Called when the `game_window` has reported that it is ready to
+        /// close.
+        ///
+        /// Any scene may return false from this method to prevent the window
+        /// from closing, for instance to ask the user if they would like to
+        /// save before closing.
+        virtual bool on_close() { return true; }
 
     public:
         game_scene();

--- a/include/mope_game_engine/game_window.hxx
+++ b/include/mope_game_engine/game_window.hxx
@@ -22,15 +22,29 @@ namespace mope
         virtual auto get_context() -> std::unique_ptr<gl_context> = 0;
         virtual void process_inputs() = 0;
         virtual void swap() = 0;
+
+        /// Return whether the window is trying to close.
+        ///
+        /// This can return `true` after the user clicks the "close" button on
+        /// the window (if present), or if the @ref game_engine has told the
+        /// window to close with the `close()` method.
         virtual auto wants_to_close() const -> bool = 0;
 
-        /// Indicate that this window should close.
+        /// Indicate that this window should or shouldn't close.
+        ///
+        /// The @ref game_engine will call this method with @p should_close true
+        /// when there are no more scenes and the @ref game_engine is done.
+        ///
+        /// The @ref game_engine will also call this method with @p should_close
+        /// false in the event that the window has said it wants to close, but
+        /// we want to prevent that from happening (because the game needs to
+        /// perform some kind of cleanup first).
         ///
         /// Note that the window should not actually be destroyed, as there will
         /// be an outstanding OpenGL context when this is called. A typical
         /// implementation will cause @ref wants_to_close() to return `true`.
         /// Destruction of the window is beyond the purview of @ref game_engine.
-        virtual void close() = 0;
+        virtual void close(bool should_close = true) = 0;
 
         /// Return a bitset representing which keys are currently pressed.
         virtual auto key_states() const -> std::bitset<256> = 0;

--- a/src/game_scene.cxx
+++ b/src/game_scene.cxx
@@ -78,6 +78,3 @@ void mope::game_scene::render(double alpha)
 {
     ensure_renderer().render(*this, alpha);
 }
-
-void mope::game_scene::on_load(game_engine& engine) {}
-void mope::game_scene::on_unload(game_engine& engine) {}


### PR DESCRIPTION
- Game scenes now get an opportunity to perform cleanup and tell the window not to close before the game loop actually ends.
- Some but not all of the messy details were moved out of `run()` and into smaller methods on `game_engine`. This is basically just because `run()` was getting kind of cluttered.